### PR TITLE
GH-20/improve-today-command-execution-speed

### DIFF
--- a/pkg/initialize/initialize.go
+++ b/pkg/initialize/initialize.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
@@ -166,4 +167,17 @@ func GetClient() *http.Client {
 	}
 
 	return config.Client(context.Background(), tok)
+}
+
+// Timer returns a function that prints the name argument and
+// the elapsed time between the call to timer and the call to
+// the returned function. The returned function is intended to
+// be used in a defer statement:
+//
+//   defer timer("sum")()
+func Timer(name string) func() {
+	start := time.Now()
+	return func() {
+		fmt.Printf("%s took %v\n", name, time.Since(start))
+	}
 }


### PR DESCRIPTION
Resolves #20 
Looks like the HTTP call made to google is what takes the most amount of time.
At this point I'm unsure on how I could improve it, maybe some local caching strategy?
Well, I'll keep the timer function for now!